### PR TITLE
fix: fix livereload deprecation warning

### DIFF
--- a/lib/commands/serve.js
+++ b/lib/commands/serve.js
@@ -28,7 +28,7 @@ module.exports = function (path, openInBrowser, port, livereloadPort) {
   server.use(serveStatic(path))
   server.listen(port)
   lrserver.createServer({
-    exts: ['md'],
+    extraExts: ['md'],
     exclusions: ['node_modules/'],
     port: livereloadPort
   }).watch(path)

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "docsify": ">=3",
     "docsify-server-renderer": ">=4",
     "fs-extra": "^2.1.2",
-    "livereload": "^0.6.2",
+    "livereload": "^0.7.0",
     "lru-cache": "^4.1.1",
     "open": "^0.0.5",
     "serve-static": "^1.12.1",


### PR DESCRIPTION
Since livereload v0.6.3, we get the warning:

```
$ docsify serve ./docs --open
*** DEPRECATION WARNING *** The exts option will REPLACE extensions in 0.6.4. ***
```

As the author of livereload [commented](https://github.com/napcs/node-livereload/issues/94#issuecomment-361306675): in the next version, the exts option will REPLACE all the default extensions with only what you specify. That means `exts: ['md']` will only watch markdown files. If we want to also watch default extensions, we should use `extraExts: ['md']`.

This PR upgrade `livereload` and use `extraExts` option to fix the warning.