### PR TITLE
fix(travis): restore green builds on develop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,5 @@ cache:
     - ./node_modules
 install:
   - npm install
-  - npm install -g gulp
 script:
-  - gulp lint
+  - ./node_modules/.bin/gulp lint


### PR DESCRIPTION
It seems builds are red on develop which blocks other PRs, [example](https://travis-ci.org/docsifyjs/docsify-cli/builds/460089805)

```
$ npm install -g gulp
npm WARN deprecated gulp-util@3.0.8: gulp-util is deprecated - replace it, following the guidelines at https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5
npm WARN deprecated graceful-fs@3.0.11: please upgrade to graceful-fs 4 for compatibility with current and future versions of Node.js
npm WARN deprecated minimatch@2.0.10: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
npm WARN deprecated minimatch@0.2.14: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
npm WARN deprecated graceful-fs@1.2.3: please upgrade to graceful-fs 4 for compatibility with current and future versions of Node.js
/home/travis/.nvm/versions/node/v11.2.0/bin/gulp -> /home/travis/.nvm/versions/node/v11.2.0/lib/node_modules/gulp/bin/gulp.js
+ gulp@3.9.1
added 253 packages from 162 contributors in 9.453s
0.83s$ gulp lint
[05:19:14] Failed to load external module @babel/register
[05:19:14] Requiring external module babel-register
fs.js:25
'use strict';
^
ReferenceError: internalBinding is not defined
    at fs.js:25:1
    at req_ (/home/travis/build/docsifyjs/docsify-cli/node_modules/natives/index.js:137:5)
    at Object.req [as require] (/home/travis/build/docsifyjs/docsify-cli/node_modules/natives/index.js:54:10)
    at Object.<anonymous> (/home/travis/build/docsifyjs/docsify-cli/node_modules/vinyl-fs/node_modules/graceful-fs/fs.js:1:37)
    at Module._compile (internal/modules/cjs/loader.js:722:30)
    at Module._extensions..js (internal/modules/cjs/loader.js:733:10)
    at Object.require.extensions.(anonymous function) [as .js] (/home/travis/build/docsifyjs/docsify-cli/node_modules/babel-register/lib/node.js:152:7)
    at Module.load (internal/modules/cjs/loader.js:620:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:560:12)
    at Function.Module._load (internal/modules/cjs/loader.js:552:3)
The command "gulp lint" exited with 1.
```
