### PR TITLE
fix(chore): warn on unknown commands and command recommendation

### DIFF
--- a/bin/docsify
+++ b/bin/docsify
@@ -20,6 +20,7 @@ require("yargonaut")
 const yargs = require("yargs")
   .demandCommand(1, chalk.red("[ERROR] 0 arguments passed. Please specify a command"))
   .strict()
+  .recommendCommands()
   .usage(chalk.bold(y18n.__("usage") + ": docsify <init|serve> <path>"))
   .command({
     command: "init [path]",

--- a/bin/docsify
+++ b/bin/docsify
@@ -19,6 +19,7 @@ require("yargonaut")
 
 const yargs = require("yargs")
   .demandCommand(1, chalk.red("[ERROR] 0 arguments passed. Please specify a command"))
+  .strict()
   .usage(chalk.bold(y18n.__("usage") + ": docsify <init|serve> <path>"))
   .command({
     command: "init [path]",


### PR DESCRIPTION
closes #73 
- Warn on firing in unknown commands
- Suggest matching commands if the user makes a typo.