### PR TITLE
feat(chore): suggest matching commands

### DIFF
--- a/bin/docsify
+++ b/bin/docsify
@@ -19,6 +19,7 @@ require("yargonaut")
 
 const yargs = require("yargs")
   .demandCommand(1, chalk.red("[ERROR] 0 arguments passed. Please specify a command"))
+  .recommendCommands()
   .usage(chalk.bold(y18n.__("usage") + ": docsify <init|serve> <path>"))
   .command({
     command: "init [path]",


### PR DESCRIPTION
Suggest matching commands if the user makes a typo.

```bash
$ docsify ini
Usage: docsify <init|serve> <path>

Commands:
  init [path]   Creates new docs
  serve [path]  Run local server to preview site.
  start <path>  Server for SSR

Global Options
  --help, -h     Show help                                             [boolean]
  --version, -v  Show version number                                   [boolean]

Documentation:
  https://docsifyjs.github.io/docsify
  https://docsifyjs.github.io/docsify-cli

Development:
  https://github.com/docsifyjs/docsify-cli/blob/master/CONTRIBUTING.md


Did you mean init?
```