### PR TITLE
refactor: automate build with rollup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .vscode/
 node_modules/
 yarn.lock
+bin/

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,4 @@ cache:
     - ./node_modules
 install:
   - npm install
+  - npm run build

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -1,11 +1,8 @@
-#!/usr/bin/env node
-
-"use strict";
+const chalk = require("chalk");
+const updateNotifier = require("update-notifier");
 
 const pkg = require("../package.json");
 const run = require("../lib");
-const chalk = require("chalk");
-const updateNotifier = require("update-notifier");
 
 updateNotifier({ pkg: pkg }).notify();
 

--- a/package.json
+++ b/package.json
@@ -22,8 +22,11 @@
     "docsify": "bin/docsify"
   },
   "scripts": {
-  	"test": "ava e2e/index.js",
-    "release": "standard-version"
+    "test": "ava e2e/index.js",
+    "release": "standard-version",
+    "prebuild": "rimraf bin",
+    "build": "rollup -c",
+    "prerelease": "npm run build"
   },
   "files": [
     "bin",
@@ -52,6 +55,9 @@
     "cors": "^2.8.1",
     "eslint": "^6.5.1",
     "execa": "^4.0.0",
+    "rimraf": "^3.0.0",
+    "rollup": "^1.27.13",
+    "rollup-plugin-executable": "^1.5.2",
     "standard-version": "^7.0.1"
   },
   "keywords": [

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,11 @@
+import executable from "rollup-plugin-executable";
+
+module.exports = {
+  input: "lib/cli.js", // Entry file
+  plugins: [executable()],
+  output: {
+    file: "bin/docsify",
+    format: "cjs", // Compiles to CJS
+    banner: "#!/usr/bin/env node" // Adds node shebang on top of the file
+  }
+};


### PR DESCRIPTION
fixes #82.

Basically the proposal is just add a very simple command which does the build process. Consequently is no need to keep `bin/docsify` versioned anymore.

Also it may allow you guys to write ES6 code in the future if you want. The only configuration it'll need is `https://github.com/rollup/rollup-plugin-babel`.