### PR TITLE
Serve several static paths

### DIFF
--- a/lib/commands/serve.js
+++ b/lib/commands/serve.js
@@ -25,48 +25,58 @@ module.exports = function (
       livereloadPort = p
     })
     .then(_ => {
-      path = resolve(path || '.')
-      const indexFile = resolve(path, indexName || 'index.html')
-
-      if (!exists(indexFile)) {
-        const msg =
-          '\nNo docs found ' +
-          indexFile +
-          '\nPlease run ' +
-          chalk.green('docsify init') +
-          ' first.\n'
-        console.log(msg)
-        process.exit(0)
-      }
-
-      const server = connect()
+      const server = connect();
       server.use(
         livereload({
           port: livereloadPort
         })
-      )
-      server.use(serveStatic(path, {index: indexName}))
-      server.listen(port)
+      );
+
+      let indexFileFound = false;
+      let indexFile;
+      path.split(",").forEach((path)=> {
+        path = resolve(path || ".");
+        indexFile = resolve(path, indexName || "index.html");
+        if (exists(indexFile)) {
+          indexFileFound = true
+        }
+        server.use(serveStatic(path, { index: indexName }));
+      });
+
+      if (!indexFileFound) {
+        const msg =
+          "\nNo docs found " +
+          indexFile +
+          "\nPlease run " +
+          chalk.green("docsify init") +
+          " first.\n";
+        console.log(msg);
+        process.exit(0);
+      }
+
+      
+      
+      server.listen(port);
       lrserver
         .createServer({
-          extraExts: ['md'],
-          exclusions: ['node_modules/'],
+          extraExts: ["md"],
+          exclusions: ["node_modules/"],
           port: livereloadPort
         })
-        .watch(path)
+        .watch(path.split(","));
 
       if (openInBrowser) {
-        open(`http://localhost:${port}`)
+        open(`http://localhost:${port}`);
       }
 
       const msg =
-        '\nServing ' +
+        "\nServing " +
         chalk.green(`${path}`) +
-        ' now.\n' +
-        'Listening at ' +
+        " now.\n" +
+        "Listening at " +
         chalk.green(`http://localhost:${port}`) +
-        '\n'
-      console.log(msg)
+        "\n";
+      console.log(msg);
     })
     .catch(err => {
       console.error(err.message)


### PR DESCRIPTION
# Goal
The goal of this PR is to allow to server several static paths to be able to seperate easily, the HTML elements of docsify (css, index.html, so on) and the md files folder.

# Syntax
`docsify serve html,md --port 3001`

`path` can have several paths coma separated.
