### PR TITLE
Add options to generate docs with sidebar, navbar and coverpage

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -52,6 +52,11 @@ docsify init <path> [--local false] [--theme vue]
   * Type: string
   * Default: `vue`
   * Description: Choose a theme, defaults to `vue`, other choices are `buble`, `dark` and `pure`.
+* `--sidebar` option:
+  * Shorthand: `-s`
+  * Type: boolean
+  * Default: `false`
+  * Description: Include sidebar when generating a new doc, defaults to `false`.
 
 ### `serve` command
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,9 +35,9 @@ npm i docsify-cli -g
 Use `init` to generate your docs.
 
 ```shell
-docsify init <path> [--local false] [--theme vue]
+docsify init <path> [--local false] [--theme vue] [--sidebar false] [--navbar false]
 
-# docsify i <path> [--local false] [--theme vue]
+# docsify i <path> [--local false] [--theme vue] [--sidebar false] [--navbar false]
 ```
 
 `<path>` defaults to the current directory. Use relative paths like `./docs` (or `docs`).
@@ -57,6 +57,11 @@ docsify init <path> [--local false] [--theme vue]
   * Type: boolean
   * Default: `false`
   * Description: Include sidebar when generating a new doc, defaults to `false`.
+* `--navbar` option:
+  * Shorthand: `-n`
+  * Type: boolean
+  * Default: `false`
+  * Description: Include navbar when generating a new doc, defaults to `false`.
 
 ### `serve` command
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,9 +35,9 @@ npm i docsify-cli -g
 Use `init` to generate your docs.
 
 ```shell
-docsify init <path> [--local false] [--theme vue] [--sidebar false] [--navbar false]
+docsify init <path> [--local false] [--theme vue] [--sidebar false] [--navbar false] [--coverpage false]
 
-# docsify i <path> [--local false] [--theme vue] [--sidebar false] [--navbar false]
+# docsify i <path> [--local false] [--theme vue] [--sidebar false] [--navbar false] [--coverpage false]
 ```
 
 `<path>` defaults to the current directory. Use relative paths like `./docs` (or `docs`).
@@ -62,6 +62,11 @@ docsify init <path> [--local false] [--theme vue] [--sidebar false] [--navbar fa
   * Type: boolean
   * Default: `false`
   * Description: Include navbar when generating a new doc, defaults to `false`.
+* `--coverpage` option:
+  * Shorthand: `-c`
+  * Type: boolean
+  * Default: `false`
+  * Description: Include coverpage when generating a new doc, defaults to `false`.
 
 ### `serve` command
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -41,9 +41,17 @@ require('yargs')
           nargs: 1,
           requiresArg: true,
           type: 'string'
+        },
+        sidebar: {
+          alias: 's',
+          default: false,
+          desc: chalk.gray(y18n.__('init.sidebar')),
+          nargs: 0,
+          requiresArg: false,
+          type: 'boolean'
         }
       }),
-    handler: argv => run.init(argv.path, argv.local, argv.theme)
+    handler: argv => run.init(argv.path, argv.local, argv.theme, argv.sidebar)
   })
   .command({
     command: 'serve [path]',

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -57,9 +57,17 @@ require('yargs')
           nargs: 0,
           requiresArg: false,
           type: 'boolean'
+        },
+        coverpage: {
+          alias: 'c',
+          default: false,
+          desc: chalk.gray(y18n.__('init.coverpage')),
+          nargs: 0,
+          requiresArg: false,
+          type: 'boolean'
         }
       }),
-    handler: argv => run.init(argv.path, argv.local, argv.theme, argv.sidebar, argv.navbar)
+    handler: argv => run.init(argv.path, argv.local, argv.theme, argv.sidebar, argv.navbar, argv.coverpage)
   })
   .command({
     command: 'serve [path]',

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -49,9 +49,17 @@ require('yargs')
           nargs: 0,
           requiresArg: false,
           type: 'boolean'
+        },
+        navbar: {
+          alias: 'n',
+          default: false,
+          desc: chalk.gray(y18n.__('init.navbar')),
+          nargs: 0,
+          requiresArg: false,
+          type: 'boolean'
         }
       }),
-    handler: argv => run.init(argv.path, argv.local, argv.theme, argv.sidebar)
+    handler: argv => run.init(argv.path, argv.local, argv.theme, argv.sidebar, argv.navbar)
   })
   .command({
     command: 'serve [path]',

--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -10,7 +10,7 @@ const replace = function (file, tpl, replace) {
 }
 
 // eslint-disable-next-line
-module.exports = function (path = '', local, theme, sidebar) {
+module.exports = function (path = '', local, theme, sidebar, navbar) {
   const msg =
     '\n' +
     chalk.green('Initialization succeeded!') +
@@ -47,6 +47,11 @@ module.exports = function (path = '', local, theme, sidebar) {
   if (sidebar) {
     cp(pwd('template/_sidebar.md'), target('_sidebar.md'))
     replace(target(filename), 'window.$docsify = {', 'window.$docsify = {\n      loadSidebar: true,')
+  }
+
+  if (navbar) {
+    cp(pwd('template/_navbar.md'), target('_navbar.md'))
+    replace(target(filename), 'window.$docsify = {', 'window.$docsify = {\n      loadNavbar: true,')
   }
 
   if (pkg.name) {

--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -10,7 +10,7 @@ const replace = function (file, tpl, replace) {
 }
 
 // eslint-disable-next-line
-module.exports = function (path = '', local, theme) {
+module.exports = function (path = '', local, theme, sidebar) {
   const msg =
     '\n' +
     chalk.green('Initialization succeeded!') +
@@ -43,6 +43,11 @@ module.exports = function (path = '', local, theme) {
   cp(pwd('template/.nojekyll'), target('.nojekyll'))
 
   replace(target(filename), 'vue.css', `${theme}.css`)
+
+  if (sidebar) {
+    cp(pwd('template/_sidebar.md'), target('_sidebar.md'))
+    replace(target(filename), 'window.$docsify = {', 'window.$docsify = {\n      loadSidebar: true,')
+  }
 
   if (pkg.name) {
     replace(

--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -10,7 +10,7 @@ const replace = function (file, tpl, replace) {
 }
 
 // eslint-disable-next-line
-module.exports = function (path = '', local, theme, sidebar, navbar) {
+module.exports = function (path = '', local, theme, sidebar, navbar, coverpage) {
   const msg =
     '\n' +
     chalk.green('Initialization succeeded!') +
@@ -52,6 +52,11 @@ module.exports = function (path = '', local, theme, sidebar, navbar) {
   if (navbar) {
     cp(pwd('template/_navbar.md'), target('_navbar.md'))
     replace(target(filename), 'window.$docsify = {', 'window.$docsify = {\n      loadNavbar: true,')
+  }
+
+  if (coverpage) {
+    cp(pwd('template/_coverpage.md'), target('_coverpage.md'))
+    replace(target(filename), 'window.$docsify = {', 'window.$docsify = {\n      coverpage: true,')
   }
 
   if (pkg.name) {

--- a/lib/template/_coverpage.md
+++ b/lib/template/_coverpage.md
@@ -1,0 +1,14 @@
+<!-- _coverpage.md -->
+
+![logo](_media/icon.svg)
+
+# docsify <small>3.5</small>
+
+> A magical documentation site generator.
+
+- Simple and lightweight (~21kB gzipped)
+- No statically built html files
+- Multiple themes
+
+[GitHub](https://github.com/docsifyjs/docsify/)
+[Get Started](#docsify)

--- a/lib/template/_navbar.md
+++ b/lib/template/_navbar.md
@@ -1,0 +1,4 @@
+<!-- _navbar.md -->
+
+* [En](/)
+* [chinese](/zh-cn/)

--- a/lib/template/_sidebar.md
+++ b/lib/template/_sidebar.md
@@ -1,0 +1,4 @@
+<!-- docs/_sidebar.md -->
+
+* [Home](/)
+* [Guide](guide.md)

--- a/tools/locales/en.json
+++ b/tools/locales/en.json
@@ -8,6 +8,7 @@
   "init.theme": "Theme file to be used.",
   "init.sidebar": "Include sidebar when generating a new doc, defaults to `false`.",
   "init.navbar": "Include navbar when generating a new doc, defaults to `false`.",
+  "init.coverpage": "Include coverpage when generating a new doc, defaults to `false`.",
   "serve": "Run local server to preview site.",
   "serve.open": "Open docs in default browser. To explicitly set --open to false you may use --no-open.",
   "serve.port": "Listen port.",

--- a/tools/locales/en.json
+++ b/tools/locales/en.json
@@ -7,6 +7,7 @@
   "init.local": "Copy docsify files to local. To explicitly set --local to false you may use --no-local.",
   "init.theme": "Theme file to be used.",
   "init.sidebar": "Include sidebar when generating a new doc, defaults to `false`.",
+  "init.navbar": "Include navbar when generating a new doc, defaults to `false`.",
   "serve": "Run local server to preview site.",
   "serve.open": "Open docs in default browser. To explicitly set --open to false you may use --no-open.",
   "serve.port": "Listen port.",

--- a/tools/locales/en.json
+++ b/tools/locales/en.json
@@ -6,6 +6,7 @@
   "start": "Server for SSR",
   "init.local": "Copy docsify files to local. To explicitly set --local to false you may use --no-local.",
   "init.theme": "Theme file to be used.",
+  "init.sidebar": "Include sidebar when generating a new doc, defaults to `false`.",
   "serve": "Run local server to preview site.",
   "serve.open": "Open docs in default browser. To explicitly set --open to false you may use --no-open.",
   "serve.port": "Listen port.",


### PR DESCRIPTION
When I create documentations with docsify, I like to include the coverpage, sidebar and navbar features to take advantage of these amazing resources. So, I decided to automate this process creating options to the `init` command to include these templates.

So, you can include coverpage, for example, using this command

```sh
docsify init ./ --coverpage

# or short
docsify init ./ -c
```

```sh
docsify init <path> [--local false] [--theme vue] [--sidebar false] [--navbar false] [--coverpage false]
docsify init <path> [-l false] [-t vue] [-s false] [-n false] [-c false]
```

### CHANGES

- `lib/cli.js`
- `lib/commands/init.js`
- Docs:
  - `docs/README.md`
  - `tools/locale/en.json`
- Add templates `_coverpage.md`, `_sidebar.md`, and `_navbar.md` files to `lib/template`


I hope that helps docsify users.