### PR TITLE
fix: Allow config flag to take a parameter

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -94,7 +94,7 @@ require('yargs')
           alias: 'c',
           default: false,
           desc: chalk.gray(y18n.__('start.config')),
-          nargs: 0,
+          nargs: 1,
           requiresArg: false,
           type: 'string'
         },


### PR DESCRIPTION
fixes #95 

Resolves the error that appears like this without the fix.

```
docsify start . --config ssr.config.js
```
```sh
Unexpected argument: ./ssr.config.js
```