### PR TITLE
feat: Included docsify version in url

### DIFF
--- a/lib/template/index.html
+++ b/lib/template/index.html
@@ -6,7 +6,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
   <meta name="description" content="Description">
   <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
-  <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/docsify/lib/themes/vue.css">
+  <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/docsify@4/lib/themes/vue.css">
 </head>
 <body>
   <div id="app"></div>
@@ -17,6 +17,6 @@
     }
   </script>
   <!-- Docsify v4 -->
-  <script src="//cdn.jsdelivr.net/npm/docsify@4/lib/docsify.min.js"></script>
+  <script src="//cdn.jsdelivr.net/npm/docsify@4"></script>
 </body>
 </html>

--- a/lib/template/index.html
+++ b/lib/template/index.html
@@ -16,6 +16,7 @@
       repo: ''
     }
   </script>
-  <script src="//cdn.jsdelivr.net/npm/docsify/lib/docsify.min.js"></script>
+  <!-- Docsify v4 -->
+  <script src="//cdn.jsdelivr.net/npm/docsify@4/lib/docsify.min.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Fixes #58 

`init` now creates `index.html` with major version in URL. 

```html
<script src="//cdn.jsdelivr.net/npm/docsify@4/lib/docsify.min.js"></script>
```

Updated docsify docs accordingly [#1225](https://github.com/docsifyjs/docsify/pull/1225)
