### PR TITLE
fix: cli start Error [ERR_STREAM_WRITE_AFTER_END]: write after end

### DIFF
--- a/lib/commands/start.js
+++ b/lib/commands/start.js
@@ -71,6 +71,7 @@ module.exports = function (path, configFile, port) {
       ) {
         res.writeHead(404)
         res.end()
+        return
       }
 
       Promise.resolve(cached.get(req.url) || renderer.renderToString(req.url))


### PR DESCRIPTION
Repeatedly call response.end()