### PR TITLE
fix: Support refresh and livereload in serve when using routerMode history (#132)

### DIFF
--- a/lib/commands/serve.js
+++ b/lib/commands/serve.js
@@ -3,6 +3,7 @@
 const serveStatic = require('serve-static')
 const connect = require('connect')
 const livereload = require('connect-livereload')
+const history = require('connect-history-api-fallback')
 const lrserver = require('livereload')
 const open = require('open')
 const chalk = require('chalk')
@@ -27,7 +28,8 @@ module.exports = function (
     })
     .then(_ => {
       path = resolve(path || '.')
-      const indexFile = resolve(path, indexName || 'index.html')
+      const indexFileName = indexName || 'index.html'
+      const indexFile = resolve(path, indexFileName)
 
       if (!exists(indexFile)) {
         const msg =
@@ -46,6 +48,7 @@ module.exports = function (
           port: livereloadPort
         })
       )
+      server.use(history({index: '/' + indexFileName}))
       server.use(serveStatic(path, {index: indexName}))
       server.listen(port)
       lrserver

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
   "dependencies": {
     "chalk": "^2.4.2",
     "connect": "^3.6.0",
+    "connect-history-api-fallback": "^1.6.0",
     "connect-livereload": "^0.6.0",
     "cp-file": "^7.0.0",
     "docsify": "^4.12.2",


### PR DESCRIPTION
When using `docsify serve` on a site which uses [routerMode: history](https://docsify.js.org/#/configuration?id=routermode) and you either refresh the page or change the site, triggering a live reload, you usually get a 404.

With this, the node connect server will serve the index file for most requests, using npm package [connect-history-api-fallback](https://www.npmjs.com/package/connect-history-api-fallback).

This should solve #132