### PR TITLE
Added option to parse markdown files and extract their titles

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -130,9 +130,16 @@ require('yargs')
           nargs: 1,
           requiresArg: true,
           type: 'string'
+        },
+        'markdown-titles': {
+          alias: 't',
+          default: false,
+          desc: chalk.gray(y18n.__('generate.markdown_titles')),
+          nargs: 0,
+          type: 'boolean'
         }
       }),
-    handler: argv => run.generate(argv.path, argv.sidebar)
+    handler: argv => run.generate(argv.path, argv.sidebar, {markdown_titles: argv['markdown-titles'], index_file: argv['index-file']})
   })
   .help()
   .option('help', {

--- a/lib/commands/generate.js
+++ b/lib/commands/generate.js
@@ -6,9 +6,10 @@ const {cwd, exists} = require('../util')
 const path = require('path')
 const logger = require('../util/logger')
 const ignoreFiles = ['_navbar', '_coverpage', '_sidebar']
+const marked = require('marked')
 
 // eslint-disable-next-line
-module.exports = function (path = '', sidebar) {
+module.exports = function (path = '', sidebar, options) {
   const cwdPath = cwd(path || '.')
 
   if (exists(cwdPath)) {
@@ -16,7 +17,7 @@ module.exports = function (path = '', sidebar) {
       const sidebarPath = cwdPath + '/' + sidebar || '_sidebar.md'
 
       if (!exists(sidebarPath)) {
-        genSidebar(cwdPath, sidebarPath)
+        genSidebar(cwdPath, sidebarPath, options)
         logger.success(`Successfully generated the sidebar file '${sidebar}'.`)
         return true
       }
@@ -30,13 +31,13 @@ module.exports = function (path = '', sidebar) {
   logger.error(`${cwdPath} directory does not exist.`)
 }
 
-function genSidebar(cwdPath, sidebarPath) {
+function genSidebar(cwdPath, sidebarPath, options) {
   let tree = ''
   let lastPath = ''
   let nodeName = ''
-  getDirFiles(cwdPath, function (pathname) {
-    path.relative(pathname, cwdPath)
-    pathname = pathname.replace(cwdPath + '/', '')
+  getDirFiles(cwdPath, function (fullpathname) {
+    path.relative(fullpathname, cwdPath)
+    const pathname = fullpathname.replace(cwdPath + '/', '')
     let filename = path.basename(pathname, '.md')
     let splitPath = pathname.split(path.sep)
 
@@ -44,7 +45,22 @@ function genSidebar(cwdPath, sidebarPath) {
       return true
     }
 
-    nodeName = '- [' + toCamelCase(filename) + '](' + pathname + ')' + os.EOL
+    let entryTitle = null
+    if (options.markdown_titles) {
+      const lexedTokens = marked.lexer(fs.readFileSync(fullpathname).toString())
+        .filter(token => token.type === 'heading')
+        .sort((a, b) => (a.depth < b.depth))
+        .map(i => i.text)
+      if (lexedTokens.length > 0) {
+        entryTitle = lexedTokens[0]
+      }
+    }
+
+    if (entryTitle === null) {
+      entryTitle = toCamelCase(filename)
+    }
+
+    nodeName = '- [' + entryTitle + '](' + pathname + ')' + os.EOL
 
     if (splitPath.length > 1) {
       if (splitPath[0] !== lastPath) {

--- a/tools/locales/en.json
+++ b/tools/locales/en.json
@@ -13,6 +13,7 @@
   "serve.indexname": "Custom filename instead of index.html to serve by default",
   "generate": "Docsify's generators",
   "generate.sidebar": "Generate sidebar file",
+  "generate.markdown_titles": "Use markdown parser to get titles instead of guessing by filenames",
   "livereload.port": "livereload Listen port.",
   "usage": "Usage",
   "version": "Show version number"


### PR DESCRIPTION
Now generator is using markdown filenames to guess menu title.

This PR introduces an option to use title in markdown file instead.

USAGE:

```
docsify generate ../docs --markdown-titles
```

it will parse every markdown file during generating sidebar and extract title. If there is no titles, filename (the old way) will be used as fallback