### PR TITLE
build(deps): remove unused lru-cache dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "fs-extra": "^8.1.0",
         "get-port": "^5.0.0",
         "livereload": "^0.9.2",
-        "lru-cache": "^5.1.1",
         "open": "^6.4.0",
         "serve-static": "^1.12.1",
         "yargonaut": "^1.1.2",
@@ -5302,14 +5301,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "dependencies": {
-        "yallist": "^3.0.2"
-      }
-    },
     "node_modules/make-dir": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.0.tgz",
@@ -8245,11 +8236,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
       "integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ=="
-    },
-    "node_modules/yallist": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
     },
     "node_modules/yargonaut": {
       "version": "1.1.4",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "fs-extra": "^8.1.0",
     "get-port": "^5.0.0",
     "livereload": "^0.9.2",
-    "lru-cache": "^5.1.1",
     "open": "^6.4.0",
     "serve-static": "^1.12.1",
     "yargonaut": "^1.1.2",


### PR DESCRIPTION
`lru-cache@^5.1.1` is declared in `dependencies` but is not imported anywhere in the
project. Its only occurrence in the whole repository is the `package.json` line itself.

Everyone who installs `docsify-cli` gets it, and nothing ever loads it.

Verified at b9d118f on Node 20.20.0 / npm 10.8.2, Windows:

- `git grep -E "(from|require\(|import\()\s*['\"]lru-cache"` returns nothing, and a plain
  `git grep` for `lru-cache` or `LRU` outside the lockfile matches only `package.json:61`.
- `npm run build` (rollup) after the change: exit 0, `lib/cli.js → bin/docsify` created as
  before. Nothing was being bundled from it either.
- `npm test` before the change: 9 tests failed. After the change: 9 tests failed. The
  **set** of failing titles is identical, diffed rather than counted:

  ```
  cli › shows up help message without any args
  cli › shows help with -h flag
  cli › shows help with --help flag
  cli › shows version information with -v flag
  cli › shows version information with --version flag
  cli › rejects promise due to error on passing in an unknown command
  commands › generate › generate _sidebar.md
  commands › init › generates docs directory
  commands › init › force generates docs directory with --local flag
  ```

  Those 9 are pre-existing on this machine and unrelated to this change — they are the
  e2e tests that shell out, and they fail the same way on a clean checkout. `pretest` runs
  `eslint .`, which is clean on both sides.

- `npm install` reports `removed 2 packages`: `lru-cache` and `yallist`, which came in only
  as its dependency.

I have not touched anything else. If you would rather I re-run the suite somewhere the e2e
tests pass before this is merged, I'm happy to, but the failing set being identical is what
tells you the change is inert.
